### PR TITLE
fix: remove unneeded hw-accordion__icon

### DIFF
--- a/packages/accordion/src/AccordionItem.jsx
+++ b/packages/accordion/src/AccordionItem.jsx
@@ -78,7 +78,6 @@ const AccordionItem = ({ title, children, expanded }) => {
                     className='hw-accordion__icon'
                     rotation={showExpanded() ? 90 : 0}
                 />
-                <div className='hw-accordion__icon' />
             </button>
             <div id={id} className='hw-accordion__contents' ref={contentRef}>
                 {showExpanded() && children}


### PR DESCRIPTION
it caused the old plus/minus icon to be shown when mixed with the global hedwig.css