### PR TITLE
set font-display: swap

### DIFF
--- a/packages/core/sass/fonts.css
+++ b/packages/core/sass/fonts.css
@@ -32,6 +32,7 @@
   src: url("../assets/fonts/PostenSans-Light.woff2") format("woff2"),
     url("../assets/fonts/PostenSans-Light.woff") format("woff"),
     url("../assets/fonts/PostenSans-Light.ttf") format("truetype");
+  font-display: swap;
 }
 
 @font-face {
@@ -40,6 +41,7 @@
   src: url("../assets/fonts/PostenSans-Regular.woff2") format("woff2"),
     url("../assets/fonts/PostenSans-Regular.woff") format("woff"),
     url("../assets/fonts/PostenSans-Regular.ttf") format("truetype");
+  font-display: swap;
 }
 
 @font-face {
@@ -48,6 +50,7 @@
   src: url("../assets/fonts/PostenSans-Medium.woff2") format("woff2"),
     url("../assets/fonts/PostenSans-Medium.woff") format("woff"),
     url("../assets/fonts/PostenSans-Medium.ttf") format("truetype");
+  font-display: swap;
 }
 
 @font-face {
@@ -56,4 +59,5 @@
   src: url("../assets/fonts/PostenSans-Bold.woff2") format("woff2"),
     url("../assets/fonts/PostenSans-Bold.woff") format("woff"),
     url("../assets/fonts/PostenSans-Bold.ttf") format("truetype");
+  font-display: swap;
 }


### PR DESCRIPTION
This behaviour is default for a lot of sites. including fonts hosted on google. In practice user will see little difference, but the worst case is greatly improved. if for example the user is on a slow connection that takes time loading the fonts.

Ref.
https://pagespeed.web.dev/analysis/https-beta-sporing-posten-no-sporing/yfwb3ix39g?form_factor=mobile
https://developer.chrome.com/docs/lighthouse/performance/font-display/